### PR TITLE
feat(analyze): implement LLM-based job fit analysis with keyword fallback (#11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -14,6 +14,8 @@ pub struct AppConfig {
     pub defaults: DefaultsConfig,
     /// Display preferences.
     pub display:  DisplayConfig,
+    /// LLM provider configuration for AI-powered features.
+    pub llm:      LlmConfig,
 }
 
 /// Default values applied when creating new applications.
@@ -47,6 +49,45 @@ impl Default for DisplayConfig {
     fn default() -> Self {
         Self {
             date_format: "%Y-%m-%d".to_string(),
+        }
+    }
+}
+
+/// LLM provider configuration for AI-powered features.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LlmConfig {
+    /// API key (can also be set via `LLM_API_KEY` env var).
+    pub api_key:  Option<String>,
+    /// Base URL for OpenAI-compatible API (default: `OpenRouter`).
+    pub base_url: String,
+    /// Model identifier.
+    pub model:    String,
+}
+
+impl Default for LlmConfig {
+    fn default() -> Self {
+        Self {
+            api_key:  None,
+            base_url: "https://openrouter.ai/api/v1".to_string(),
+            model:    "google/gemini-2.5-flash".to_string(),
+        }
+    }
+}
+
+impl LlmConfig {
+    /// Merge environment variable overrides into a resolved copy.
+    ///
+    /// Priority: `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL` env vars
+    /// override values from the config file.
+    #[must_use]
+    pub fn resolve(&self) -> Self {
+        Self {
+            api_key:  std::env::var("LLM_API_KEY")
+                .ok()
+                .or_else(|| self.api_key.clone()),
+            base_url: std::env::var("LLM_BASE_URL").unwrap_or_else(|_| self.base_url.clone()),
+            model:    std::env::var("LLM_MODEL").unwrap_or_else(|_| self.model.clone()),
         }
     }
 }

--- a/src/cli/analyze.rs
+++ b/src/cli/analyze.rs
@@ -1,0 +1,292 @@
+//! Job fit analysis using LLM or keyword fallback.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    db::Database,
+    domain::Application,
+    error::{Result, TenkiError},
+    llm::{ChatMessage, LlmClient},
+};
+
+/// Result of a job fit analysis.
+#[derive(Debug, Serialize)]
+pub struct AnalysisResult {
+    /// The application ID that was analyzed.
+    pub application_id: String,
+    /// Fitness score from 0 to 100.
+    pub fitness_score:  f64,
+    /// Human-readable explanation of the score.
+    pub reason:         String,
+    /// Scoring method used: "llm" or "keyword".
+    pub method:         String,
+}
+
+/// Run job fit analysis for an application.
+pub async fn run(db: &Database, id: &str, json: bool) -> Result<()> {
+    let full_id = db.resolve_app_id(id).await?;
+    let app = db.get_application(&full_id).await?;
+
+    let jd_text = app
+        .jd_text
+        .as_deref()
+        .ok_or_else(|| TenkiError::MissingJdText {
+            id: full_id.clone(),
+        })?;
+
+    let cfg = crate::app_config::load();
+    let result = if let Some(client) = LlmClient::from_config(&cfg.llm) {
+        score_with_llm(&client, &app, jd_text)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("LLM scoring failed, falling back to keywords: {e}");
+                score_with_keywords(&app, jd_text)
+            })
+    } else {
+        tracing::info!("No LLM API key configured, using keyword scoring");
+        score_with_keywords(&app, jd_text)
+    };
+
+    // Persist to DB
+    db.update_fitness(&full_id, result.fitness_score, &result.reason)
+        .await?;
+
+    if json {
+        let json_str =
+            serde_json::to_string_pretty(&result).expect("serialization should not fail");
+        println!("{json_str}");
+    } else {
+        println!("Fitness Score: {:.0}/100", result.fitness_score);
+        println!("Method: {}", result.method);
+        println!("Reason: {}", result.reason);
+    }
+
+    Ok(())
+}
+
+/// Score a job application using the LLM API.
+async fn score_with_llm(
+    client: &LlmClient,
+    app: &Application,
+    jd_text: &str,
+) -> Result<AnalysisResult> {
+    let prompt = build_scoring_prompt(app, jd_text);
+    let response = client
+        .chat(vec![ChatMessage {
+            role:    "user".to_string(),
+            content: prompt,
+        }])
+        .await?;
+
+    let parsed = parse_llm_json(&response)?;
+    let score = parsed.score.clamp(0, 100);
+
+    Ok(AnalysisResult {
+        application_id: app.id.clone(),
+        fitness_score:  f64::from(score),
+        reason:         parsed.reason,
+        method:         "llm".to_string(),
+    })
+}
+
+/// Build the scoring prompt sent to the LLM.
+fn build_scoring_prompt(app: &Application, jd_text: &str) -> String {
+    let skills = app.skills.as_deref().unwrap_or("Not specified");
+    let notes = app.notes.as_deref().unwrap_or("None");
+    let location = app.location.as_deref().unwrap_or("Not specified");
+    let salary = app.salary.as_deref().unwrap_or("Not specified");
+    let job_type = app.job_type.as_deref().unwrap_or("Not specified");
+    let job_level = app.job_level.as_deref().unwrap_or("Not specified");
+    let is_remote = match app.is_remote {
+        Some(true) => "Yes",
+        Some(false) => "No",
+        None => "Not specified",
+    };
+
+    format!(
+        "You are evaluating a job listing for a candidate. Score how suitable this job is for the \
+         candidate on a scale of 0-100.\n\nSCORING CRITERIA:\n- Skills match (technologies, \
+         frameworks, languages): 0-30 points\n- Experience level match: 0-25 points\n- \
+         Location/remote work alignment: 0-15 points\n- Industry/domain fit: 0-15 points\n- \
+         Career growth potential: 0-15 points\n\nCANDIDATE PROFILE:\nPosition Applied: \
+         {position}\nSkills: {skills}\nNotes: {notes}\n\nJOB LISTING:\nCompany: \
+         {company}\nPosition: {position}\nLocation: {location}\nSalary: {salary}\nJob Type: \
+         {job_type}\nJob Level: {job_level}\nRemote: {is_remote}\n\nJOB \
+         DESCRIPTION:\n{jd_text}\n\nIMPORTANT: Respond with ONLY a valid JSON object. No \
+         markdown, no code fences, no explanation outside the JSON.\n\nREQUIRED FORMAT (exactly \
+         this structure):\n{{\"score\": <integer 0-100>, \"reason\": \"<1-2 sentence \
+         explanation>\"}}",
+        position = app.position,
+        company = app.company,
+    )
+}
+
+#[derive(Debug, Deserialize)]
+struct ScoringResponse {
+    score:  i32,
+    reason: String,
+}
+
+/// Parse a JSON scoring response from LLM output, handling markdown fences
+/// and surrounding text.
+fn parse_llm_json(content: &str) -> Result<ScoringResponse> {
+    let trimmed = content.trim();
+
+    // Strip markdown code fences if present
+    let cleaned = if trimmed.starts_with("```") {
+        trimmed
+            .trim_start_matches("```json")
+            .trim_start_matches("```")
+            .trim_end_matches("```")
+            .trim()
+    } else {
+        trimmed
+    };
+
+    // Try direct parse first
+    if let Ok(parsed) = serde_json::from_str::<ScoringResponse>(cleaned) {
+        return Ok(parsed);
+    }
+
+    // Try to extract JSON object from surrounding text
+    if let Some(start) = cleaned.find('{')
+        && let Some(end) = cleaned.rfind('}')
+    {
+        let json_str = &cleaned[start..=end];
+        if let Ok(parsed) = serde_json::from_str::<ScoringResponse>(json_str) {
+            return Ok(parsed);
+        }
+    }
+
+    Err(TenkiError::LlmApi {
+        message: format!(
+            "failed to parse LLM response as JSON: {}",
+            &content[..content.len().min(200)]
+        ),
+    })
+}
+
+/// Score a job application using keyword matching (fallback when LLM is
+/// unavailable).
+fn score_with_keywords(app: &Application, jd_text: &str) -> AnalysisResult {
+    let jd_lower = jd_text.to_lowercase();
+    let mut score: i32 = 50;
+
+    // Check skill overlap with JD text
+    if let Some(skills) = &app.skills {
+        let matched = skills
+            .split(',')
+            .map(str::trim)
+            .filter(|skill| !skill.is_empty())
+            .filter(|skill| jd_lower.contains(&skill.to_lowercase()))
+            .count();
+
+        score += i32::try_from(matched).unwrap_or(i32::MAX).saturating_mul(5);
+        // Cap the total score at 80 for keyword-only scoring
+        score = score.min(80);
+    }
+
+    let score = score.clamp(0, 100);
+    AnalysisResult {
+        application_id: app.id.clone(),
+        fitness_score:  f64::from(score),
+        reason:         "Scored using keyword matching (LLM API key not configured)".to_string(),
+        method:         "keyword".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_clean_json() {
+        let input = r#"{"score": 75, "reason": "Good match"}"#;
+        let result = parse_llm_json(input).expect("should parse");
+        assert_eq!(result.score, 75);
+        assert_eq!(result.reason, "Good match");
+    }
+
+    #[test]
+    fn parse_json_with_code_fences() {
+        let input = "```json\n{\"score\": 60, \"reason\": \"Partial match\"}\n```";
+        let result = parse_llm_json(input).expect("should parse");
+        assert_eq!(result.score, 60);
+    }
+
+    #[test]
+    fn parse_json_with_surrounding_text() {
+        let input = "Here is the result: {\"score\": 80, \"reason\": \"Great fit\"} end";
+        let result = parse_llm_json(input).expect("should parse");
+        assert_eq!(result.score, 80);
+    }
+
+    #[test]
+    fn parse_invalid_json_returns_error() {
+        let input = "not json at all";
+        assert!(parse_llm_json(input).is_err());
+    }
+
+    #[test]
+    fn keyword_scoring_no_skills() {
+        let app = make_test_app(None);
+        let result = score_with_keywords(&app, "Rust developer needed");
+        assert!((result.fitness_score - 50.0).abs() < f64::EPSILON);
+        assert_eq!(result.method, "keyword");
+    }
+
+    #[test]
+    fn keyword_scoring_with_matches() {
+        let app = make_test_app(Some("Rust, Python, Go".to_string()));
+        let result = score_with_keywords(&app, "We need a Rust and Python developer");
+        // 50 base + 2 matches * 5 = 60
+        assert!((result.fitness_score - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn keyword_scoring_caps_at_80() {
+        let app = make_test_app(Some(
+            "Rust, Python, Go, Java, TypeScript, React, Node".to_string(),
+        ));
+        let result =
+            score_with_keywords(&app, "Rust Python Go Java TypeScript React Node developer");
+        assert!((result.fitness_score - 80.0).abs() < f64::EPSILON);
+    }
+
+    fn make_test_app(skills: Option<String>) -> Application {
+        Application {
+            id: "test-id".to_string(),
+            company: "TestCo".to_string(),
+            position: "Developer".to_string(),
+            jd_url: None,
+            jd_text: None,
+            location: None,
+            status: "bookmarked".to_string(),
+            stage: None,
+            outcome: None,
+            fitness_score: None,
+            fitness_notes: None,
+            resume_typ: None,
+            has_resume_pdf: false,
+            salary: None,
+            salary_min: None,
+            salary_max: None,
+            salary_currency: None,
+            job_type: None,
+            is_remote: None,
+            job_level: None,
+            skills,
+            experience_range: None,
+            source: None,
+            company_url: None,
+            notes: None,
+            tailored_summary: None,
+            tailored_headline: None,
+            tailored_skills: None,
+            applied_at: None,
+            closed_at: None,
+            created_at: "2024-01-01".to_string(),
+            updated_at: "2024-01-01".to_string(),
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod analyze;
 pub mod app;
 pub mod export;
 pub mod interview;
@@ -37,10 +38,13 @@ pub enum Command {
     /// Track application stage transitions (set, list)
     #[command(subcommand)]
     Stage(StageCommand),
-    /// Analyze job fit (not yet implemented)
+    /// Analyze job fit using LLM or keyword fallback
     Analyze {
         /// Application ID (8-char prefix or full UUID)
-        id: String,
+        id:   String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Tailor resume for a job (not yet implemented)
     Tailor {
@@ -208,6 +212,9 @@ pub enum AppCommand {
         /// Whether the position is remote
         #[arg(long)]
         is_remote: Option<bool>,
+        /// Comma-separated skills (e.g. "Rust, Python, Go")
+        #[arg(long)]
+        skills:    Option<String>,
         /// New source
         #[arg(long)]
         source:    Option<String>,

--- a/src/db/application.rs
+++ b/src/db/application.rs
@@ -269,7 +269,6 @@ impl Database {
     }
 
     /// Update fitness score and notes for an application.
-    #[allow(dead_code)]
     pub async fn update_fitness(&self, id: &str, score: f64, notes: &str) -> Result<()> {
         let result = sqlx::query(
             "UPDATE applications SET fitness_score = ?1, fitness_notes = ?2, updated_at = \

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,17 @@ pub enum TenkiError {
 
     #[snafu(display("invalid URL: {input} — expected http:// or https://"))]
     InvalidUrl { input: String },
+
+    #[snafu(display("HTTP error: {source}"))]
+    Http { source: reqwest::Error },
+
+    #[snafu(display("LLM API error: {message}"))]
+    LlmApi { message: String },
+
+    #[snafu(display(
+        "missing JD text for application {id} — cannot analyze without job description"
+    ))]
+    MissingJdText { id: String },
 }
 
 pub type Result<T> = std::result::Result<T, TenkiError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod app_config;
 pub mod db;
 pub mod domain;
 pub mod error;
+pub mod llm;
 pub mod paths;
 pub mod store;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,0 +1,110 @@
+//! LLM client for OpenAI-compatible APIs.
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt as _;
+
+use crate::error::{self, Result};
+
+/// A resolved LLM client ready for API calls.
+#[derive(Debug, Clone)]
+pub struct LlmClient {
+    api_key:  String,
+    base_url: String,
+    model:    String,
+    client:   reqwest::Client,
+}
+
+/// A chat message in the `OpenAI` chat completion format.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChatMessage {
+    /// Role of the message author (e.g. "user", "system").
+    pub role:    String,
+    /// Content of the message.
+    pub content: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatRequest {
+    model:           String,
+    messages:        Vec<ChatMessage>,
+    temperature:     f64,
+    response_format: ResponseFormat,
+}
+
+#[derive(Debug, Serialize)]
+struct ResponseFormat {
+    r#type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Choice {
+    message: MessageContent,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessageContent {
+    content: String,
+}
+
+impl LlmClient {
+    /// Try to create a client from config + env vars. Returns `None` if no API
+    /// key is available.
+    pub fn from_config(cfg: &crate::app_config::LlmConfig) -> Option<Self> {
+        let resolved = cfg.resolve();
+        let api_key = resolved.api_key.as_ref()?;
+        Some(Self {
+            api_key:  api_key.clone(),
+            base_url: resolved.base_url.clone(),
+            model:    resolved.model.clone(),
+            client:   reqwest::Client::new(),
+        })
+    }
+
+    /// Send a chat completion request and return the response text.
+    pub async fn chat(&self, messages: Vec<ChatMessage>) -> Result<String> {
+        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+
+        let request = ChatRequest {
+            model: self.model.clone(),
+            messages,
+            temperature: 0.3,
+            response_format: ResponseFormat {
+                r#type: "json_object".to_string(),
+            },
+        };
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .context(error::HttpSnafu)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(crate::error::TenkiError::LlmApi {
+                message: format!("HTTP {status}: {body}"),
+            });
+        }
+
+        let chat_response: ChatResponse = response.json().await.context(error::HttpSnafu)?;
+
+        chat_response
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .ok_or(crate::error::TenkiError::LlmApi {
+                message: "empty response from LLM".to_string(),
+            })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod db;
 mod domain;
 mod error;
+mod llm;
 mod paths;
 mod store;
 
@@ -116,6 +117,7 @@ async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 job_type,
                 job_level,
                 is_remote,
+                skills,
                 source,
                 notes,
                 json,
@@ -132,6 +134,7 @@ async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
                     .maybe_job_type(job_type_str.as_deref())
                     .maybe_job_level(job_level_str.as_deref())
                     .maybe_is_remote(is_remote)
+                    .maybe_skills(skills.as_deref())
                     .maybe_source(source.as_deref())
                     .maybe_notes(notes.as_deref())
                     .build();
@@ -251,8 +254,8 @@ async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 cli::stage::list(&db, &app_id, json).await?;
             }
         },
-        Command::Analyze { id } => {
-            eprintln!("analyze not yet implemented (app: {id})");
+        Command::Analyze { id, json } => {
+            cli::analyze::run(&db, &id, json).await?;
         }
         Command::Tailor { id } => {
             eprintln!("tailor not yet implemented (app: {id})");

--- a/tests/cli_analyze.rs
+++ b/tests/cli_analyze.rs
@@ -1,0 +1,97 @@
+//! Integration tests for `tenki analyze`.
+
+mod common;
+
+use predicates::prelude::*;
+
+#[test]
+fn analyze_keyword_fallback_produces_json() {
+    let tmp = common::tenki_initialized();
+
+    // Add an application with JD text
+    common::tenki_with(&tmp)
+        .args([
+            "app",
+            "add",
+            "--company",
+            "TestCo",
+            "--position",
+            "Rust Developer",
+            "--jd-text",
+            "We need a senior Rust and Python developer with Go experience",
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    // Get the app ID
+    let output = common::tenki_with(&tmp)
+        .args(["app", "list", "--json"])
+        .output()
+        .expect("list should succeed");
+    let apps: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    let id = apps[0]["id"].as_str().expect("id should be a string");
+    let short_id = &id[..8];
+
+    // Update with skills
+    common::tenki_with(&tmp)
+        .args(["app", "update", short_id, "--skills", "Rust, Python, Go"])
+        .assert()
+        .success();
+
+    // Run analyze with --json (no LLM_API_KEY set, so keyword fallback)
+    let analyze_output = common::tenki_with(&tmp)
+        .args(["analyze", short_id, "--json"])
+        .output()
+        .expect("analyze should succeed");
+    assert!(analyze_output.status.success(), "analyze should exit 0");
+
+    let result: serde_json::Value =
+        serde_json::from_slice(&analyze_output.stdout).expect("valid JSON output");
+    assert_eq!(result["method"], "keyword");
+    assert!(result["fitness_score"].as_f64().expect("score is f64") > 0.0);
+    assert!(result["reason"].as_str().is_some());
+
+    // Verify persistence via app show
+    let show_output = common::tenki_with(&tmp)
+        .args(["app", "show", short_id, "--json"])
+        .output()
+        .expect("show should succeed");
+    let app: serde_json::Value = serde_json::from_slice(&show_output.stdout).expect("valid JSON");
+    assert!(app["fitness_score"].as_f64().is_some());
+    assert!(app["fitness_notes"].as_str().is_some());
+}
+
+#[test]
+fn analyze_missing_jd_text_fails() {
+    let tmp = common::tenki_initialized();
+
+    // Add an application without JD text
+    common::tenki_with(&tmp)
+        .args([
+            "app",
+            "add",
+            "--company",
+            "NoCo",
+            "--position",
+            "Dev",
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    let output = common::tenki_with(&tmp)
+        .args(["app", "list", "--json"])
+        .output()
+        .expect("list should succeed");
+    let apps: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    let id = apps[0]["id"].as_str().expect("id");
+    let short_id = &id[..8];
+
+    // Analyze should fail because no JD text
+    common::tenki_with(&tmp)
+        .args(["analyze", short_id])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("missing JD text"));
+}


### PR DESCRIPTION
## Summary
- Implement `tenki analyze <id>` using OpenAI-compatible LLM API for job fit scoring (0-100)
- Scoring prompt follows job-ops pattern: skills (30pts), experience (25pts), location (15pts), domain (15pts), growth (15pts)
- Automatic fallback to keyword-based scoring when no API key configured
- New `LlmConfig` in config system with env var overrides (`LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`)
- Default provider: OpenRouter with `google/gemini-2.5-flash`
- Add `--skills` flag to `app update` (was missing from CLI layer)
- Robust LLM JSON parsing (handles markdown fences, surrounding text)

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo nextest run` — 20/20 tests pass (7 unit + 2 integration new)
- [x] Keyword fallback path tested end-to-end
- [x] Missing JD text error tested

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)