### PR TITLE
feat(analyze): sync agent module and implement job fit analysis (#11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ config = "0.15"
 dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+nix = { version = "0.30", features = ["signal"] }
 snafu = "0.9"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "macros", "migrate", "chrono"] }
 tokio = { version = "1", features = ["full"] }
+tempfile = "3"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -27,7 +27,8 @@ pub enum OutputFormat {
     /// Plain text output (default for most adapters).
     #[default]
     Text,
-    /// Newline-delimited JSON stream (Claude with `--output-format stream-json`).
+    /// Newline-delimited JSON stream (Claude with `--output-format
+    /// stream-json`).
     StreamJson,
     /// Newline-delimited JSON stream (Pi with `--mode json`).
     PiStreamJson,
@@ -67,13 +68,13 @@ pub enum PromptMode {
 /// the underlying file.
 pub struct CommandSpec {
     /// The command binary to execute.
-    pub command: String,
+    pub command:     String,
     /// Fully resolved argument list (includes prompt).
-    pub args: Vec<String>,
+    pub args:        Vec<String>,
     /// If set, this string should be written to the child's stdin.
     pub stdin_input: Option<String>,
     /// Temp file handle — kept alive so the agent can read from it.
-    _temp_file: Option<NamedTempFile>,
+    _temp_file:      Option<NamedTempFile>,
 }
 
 /// A CLI backend configuration for executing prompts.
@@ -86,19 +87,21 @@ pub struct CommandSpec {
 #[derive(Debug, Clone)]
 pub struct CliBackend {
     /// The command to execute.
-    pub command: String,
+    pub command:       String,
     /// Additional arguments before the prompt.
-    pub args: Vec<String>,
+    pub args:          Vec<String>,
     /// How to pass the prompt.
-    pub prompt_mode: PromptMode,
+    pub prompt_mode:   PromptMode,
     /// Argument flag for prompt (if `prompt_mode` is `Arg`).
-    pub prompt_flag: Option<String>,
+    pub prompt_flag:   Option<String>,
     /// Output format emitted by this backend.
+    #[allow(dead_code)]
     pub output_format: OutputFormat,
     /// Environment variables to set when spawning the process.
-    pub env_vars: Vec<(String, String)>,
+    pub env_vars:      Vec<(String, String)>,
 }
 
+#[allow(dead_code)]
 impl CliBackend {
     /// Creates a backend from an [`AgentConfig`].
     ///
@@ -135,20 +138,21 @@ impl CliBackend {
     /// in non-interactive mode where it executes the prompt and exits.
     ///
     /// Emits `--output-format stream-json` for NDJSON streaming output.
-    /// Note: `--verbose` is required when using `--output-format stream-json` with `-p`.
+    /// Note: `--verbose` is required when using `--output-format stream-json`
+    /// with `-p`.
     pub fn claude() -> Self {
         Self {
-            command: "claude".to_string(),
-            args: vec![
+            command:       "claude".to_string(),
+            args:          vec![
                 "--dangerously-skip-permissions".to_string(),
                 "--verbose".to_string(),
                 "--output-format".to_string(),
                 "stream-json".to_string(),
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::StreamJson,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -157,12 +161,12 @@ impl CliBackend {
     /// Runs Claude without `-p` flag, passing prompt as a positional argument.
     pub fn claude_interactive() -> Self {
         Self {
-            command: "claude".to_string(),
-            args: vec!["--dangerously-skip-permissions".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "claude".to_string(),
+            args:          vec!["--dangerously-skip-permissions".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -172,12 +176,12 @@ impl CliBackend {
     /// `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var.
     pub fn claude_interactive_teams() -> Self {
         Self {
-            command: "claude".to_string(),
-            args: vec!["--dangerously-skip-permissions".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "claude".to_string(),
+            args:          vec!["--dangerously-skip-permissions".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![(
+            env_vars:      vec![(
                 "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
                 "1".to_string(),
             )],
@@ -189,16 +193,16 @@ impl CliBackend {
     /// Uses `kiro-cli` in headless mode with all tools trusted.
     pub fn kiro() -> Self {
         Self {
-            command: "kiro-cli".to_string(),
-            args: vec![
+            command:       "kiro-cli".to_string(),
+            args:          vec![
                 "chat".to_string(),
                 "--no-interactive".to_string(),
                 "--trust-all-tools".to_string(),
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -207,18 +211,18 @@ impl CliBackend {
     /// Uses `kiro-cli` with `--agent` flag to select a specific agent.
     pub fn kiro_with_agent(agent: String, extra_args: &[String]) -> Self {
         let mut backend = Self {
-            command: "kiro-cli".to_string(),
-            args: vec![
+            command:       "kiro-cli".to_string(),
+            args:          vec![
                 "chat".to_string(),
                 "--no-interactive".to_string(),
                 "--trust-all-tools".to_string(),
                 "--agent".to_string(),
                 agent,
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
         backend.args.extend(extra_args.iter().cloned());
         backend
@@ -228,9 +232,7 @@ impl CliBackend {
     ///
     /// Uses `kiro-cli` with the ACP subcommand for structured JSON-RPC
     /// communication over stdio instead of PTY text scraping.
-    pub fn kiro_acp() -> Self {
-        Self::kiro_acp_with_options(None, None)
-    }
+    pub fn kiro_acp() -> Self { Self::kiro_acp_with_options(None, None) }
 
     /// Creates the Kiro ACP backend with an optional agent and/or model.
     pub fn kiro_acp_with_options(agent: Option<&str>, model: Option<&str>) -> Self {
@@ -256,39 +258,40 @@ impl CliBackend {
     /// Creates the Gemini backend.
     pub fn gemini() -> Self {
         Self {
-            command: "gemini".to_string(),
-            args: vec!["--yolo".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            command:       "gemini".to_string(),
+            args:          vec!["--yolo".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Gemini in interactive mode with initial prompt (uses `-i`, not `-p`).
     ///
-    /// **Critical quirk**: Gemini requires `-i` flag for interactive+prompt mode.
-    /// Using `-p` would make it run headless and exit after one response.
+    /// **Critical quirk**: Gemini requires `-i` flag for interactive+prompt
+    /// mode. Using `-p` would make it run headless and exit after one
+    /// response.
     pub fn gemini_interactive() -> Self {
         Self {
-            command: "gemini".to_string(),
-            args: vec!["--yolo".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-i".to_string()),
+            command:       "gemini".to_string(),
+            args:          vec!["--yolo".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-i".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates the Codex backend.
     pub fn codex() -> Self {
         Self {
-            command: "codex".to_string(),
-            args: vec!["exec".to_string(), "--yolo".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "codex".to_string(),
+            args:          vec!["exec".to_string(), "--yolo".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -298,24 +301,24 @@ impl CliBackend {
     /// flags, allowing interactive TUI mode.
     pub fn codex_interactive() -> Self {
         Self {
-            command: "codex".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "codex".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates the Amp backend.
     pub fn amp() -> Self {
         Self {
-            command: "amp".to_string(),
-            args: vec!["--dangerously-allow-all".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-x".to_string()),
+            command:       "amp".to_string(),
+            args:          vec!["--dangerously-allow-all".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-x".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -325,26 +328,27 @@ impl CliBackend {
     /// requiring user confirmation for tool usage.
     pub fn amp_interactive() -> Self {
         Self {
-            command: "amp".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-x".to_string()),
+            command:       "amp".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-x".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates the Copilot backend for autonomous mode.
     ///
-    /// Uses GitHub Copilot CLI with `--allow-all-tools` for automated tool approval.
+    /// Uses GitHub Copilot CLI with `--allow-all-tools` for automated tool
+    /// approval.
     pub fn copilot() -> Self {
         Self {
-            command: "copilot".to_string(),
-            args: vec!["--allow-all-tools".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            command:       "copilot".to_string(),
+            args:          vec!["--allow-all-tools".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -354,12 +358,12 @@ impl CliBackend {
     /// requiring user confirmation for tool usage.
     pub fn copilot_interactive() -> Self {
         Self {
-            command: "copilot".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            command:       "copilot".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -369,12 +373,12 @@ impl CliBackend {
     /// Copilot's native TUI to render.
     pub fn copilot_tui() -> Self {
         Self {
-            command: "copilot".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "copilot".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -384,12 +388,12 @@ impl CliBackend {
     /// positional argument after the subcommand.
     pub fn opencode() -> Self {
         Self {
-            command: "opencode".to_string(),
-            args: vec!["run".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "opencode".to_string(),
+            args:          vec!["run".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -400,12 +404,12 @@ impl CliBackend {
     /// this launches the interactive TUI and injects the prompt.
     pub fn opencode_interactive() -> Self {
         Self {
-            command: "opencode".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("--prompt".to_string()),
+            command:       "opencode".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("--prompt".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -415,17 +419,17 @@ impl CliBackend {
     /// Emits `PiStreamJson` output format for structured event parsing.
     pub fn pi() -> Self {
         Self {
-            command: "pi".to_string(),
-            args: vec![
+            command:       "pi".to_string(),
+            args:          vec![
                 "-p".to_string(),
                 "--mode".to_string(),
                 "json".to_string(),
                 "--no-session".to_string(),
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::PiStreamJson,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -435,12 +439,12 @@ impl CliBackend {
     /// positional argument.
     pub fn pi_interactive() -> Self {
         Self {
-            command: "pi".to_string(),
-            args: vec!["--no-session".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "pi".to_string(),
+            args:          vec!["--no-session".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -451,12 +455,12 @@ impl CliBackend {
     /// `build_command()`).
     pub fn roo() -> Self {
         Self {
-            command: "roo".to_string(),
-            args: vec!["--print".to_string(), "--ephemeral".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "roo".to_string(),
+            args:          vec!["--print".to_string(), "--ephemeral".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -466,19 +470,20 @@ impl CliBackend {
     /// as a positional argument.
     pub fn roo_interactive() -> Self {
         Self {
-            command: "roo".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "roo".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates a custom backend from configuration.
     ///
     /// # Errors
-    /// Returns [`BackendError::CustomBackendRequiresCommand`] if no command is specified.
+    /// Returns [`BackendError::CustomBackendRequiresCommand`] if no command is
+    /// specified.
     pub fn custom(config: &AgentConfig) -> Result<Self> {
         let command = config
             .command
@@ -526,10 +531,7 @@ impl CliBackend {
     ///
     /// # Errors
     /// Returns error if the backend name is invalid.
-    pub fn from_name_with_args(
-        name: &str,
-        extra_args: &[String],
-    ) -> Result<Self> {
+    pub fn from_name_with_args(name: &str, extra_args: &[String]) -> Result<Self> {
         let mut backend = Self::from_name(name)?;
         backend.args.extend(extra_args.iter().cloned());
         if backend.command == "codex" {
@@ -544,7 +546,8 @@ impl CliBackend {
     /// session with an initial prompt.
     ///
     /// # Errors
-    /// Returns [`BackendError::UnknownBackend`] if the backend name is not recognized.
+    /// Returns [`BackendError::UnknownBackend`] if the backend name is not
+    /// recognized.
     pub fn for_interactive_prompt(backend_name: &str) -> Result<Self> {
         match backend_name {
             "claude" => Ok(Self::claude_interactive()),
@@ -569,12 +572,12 @@ impl CliBackend {
     /// Kiro's TUI while still passing an initial prompt.
     pub fn kiro_interactive() -> Self {
         Self {
-            command: "kiro-cli".to_string(),
-            args: vec!["chat".to_string(), "--trust-all-tools".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "kiro-cli".to_string(),
+            args:          vec!["chat".to_string(), "--trust-all-tools".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -622,7 +625,8 @@ impl CliBackend {
             args = self.filter_args_for_interactive(args);
         }
 
-        // Handle prompt passing: Roo uses --prompt-file, all others use temp file for large prompts
+        // Handle prompt passing: Roo uses --prompt-file, all others use temp file for
+        // large prompts
         let (stdin_input, temp_file) = match self.prompt_mode {
             PromptMode::Arg => {
                 // Roo headless: always use --prompt-file for all prompts
@@ -633,16 +637,12 @@ impl CliBackend {
                         match NamedTempFile::new() {
                             Ok(mut file) => {
                                 if let Err(e) = file.write_all(prompt.as_bytes()) {
-                                    tracing::warn!(
-                                        "Failed to write prompt to temp file: {e}"
-                                    );
+                                    tracing::warn!("Failed to write prompt to temp file: {e}");
                                     (prompt.to_string(), None)
                                 } else {
                                     let path = file.path().display().to_string();
                                     (
-                                        format!(
-                                            "Please read and execute the task in {path}"
-                                        ),
+                                        format!("Please read and execute the task in {path}"),
                                         Some(file),
                                     )
                                 }

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -51,11 +51,11 @@ pub struct AgentConfig {
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
-            backend: "claude".to_string(),
-            command: None,
-            args: Vec::new(),
-            prompt_mode: ConfigPromptMode::Arg,
-            prompt_flag: None,
+            backend:           "claude".to_string(),
+            command:           None,
+            args:              Vec::new(),
+            prompt_mode:       ConfigPromptMode::Arg,
+            prompt_flag:       None,
             idle_timeout_secs: 30,
         }
     }

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -4,16 +4,16 @@
 //! Supports optional execution timeout with graceful SIGTERM termination.
 //! Ported from ralph-orchestrator.
 
-use std::io::Write;
-use std::process::Stdio;
-use std::time::Duration;
+use std::{io::Write, process::Stdio, time::Duration};
 
 #[cfg(unix)]
 use nix::sys::signal::{Signal, kill};
 #[cfg(unix)]
 use nix::unistd::Pid;
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
-use tokio::process::Command;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader},
+    process::Command,
+};
 use tracing::{debug, warn};
 
 use super::backend::{CliBackend, CommandSpec};
@@ -22,14 +22,16 @@ use super::backend::{CliBackend, CommandSpec};
 #[derive(Debug)]
 pub struct ExecutionResult {
     /// The full stdout output from the CLI.
-    pub output: String,
+    pub output:    String,
     /// Captured stderr output (separate from stdout).
-    pub stderr: String,
+    #[allow(dead_code)]
+    pub stderr:    String,
     /// Whether the execution succeeded (exit code 0).
-    pub success: bool,
+    pub success:   bool,
     /// The exit code.
     pub exit_code: Option<i32>,
     /// Whether the execution was terminated due to timeout.
+    #[allow(dead_code)]
     pub timed_out: bool,
 }
 
@@ -61,19 +63,18 @@ enum StreamKind {
 
 impl CliExecutor {
     /// Creates a new executor with the given backend.
-    pub const fn new(backend: CliBackend) -> Self {
-        Self { backend }
-    }
+    pub const fn new(backend: CliBackend) -> Self { Self { backend } }
 
     /// Executes a prompt and streams output to the provided writer.
     ///
     /// Output is streamed line-by-line to the writer while being accumulated
-    /// for the return value. If `timeout` is provided and the execution produces
-    /// no stdout/stderr activity for longer than that duration, the process
-    /// is terminated and the result indicates timeout.
+    /// for the return value. If `timeout` is provided and the execution
+    /// produces no stdout/stderr activity for longer than that duration,
+    /// the process is terminated and the result indicates timeout.
     ///
-    /// When `verbose` is true, stderr output is also written to the output writer
-    /// with a `[stderr]` prefix. When false, stderr is captured but not displayed.
+    /// When `verbose` is true, stderr output is also written to the output
+    /// writer with a `[stderr]` prefix. When false, stderr is captured but
+    /// not displayed.
     pub async fn execute<W: Write + Send>(
         &self,
         prompt: &str,
@@ -92,8 +93,9 @@ impl CliExecutor {
             drop(stdin);
         }
 
-        let (accumulated_output, accumulated_stderr, timed_out) =
-            self.read_output(&mut child, &mut output_writer, timeout, verbose).await?;
+        let (accumulated_output, accumulated_stderr, timed_out) = self
+            .read_output(&mut child, &mut output_writer, timeout, verbose)
+            .await?;
 
         let status = child.wait().await?;
 
@@ -235,14 +237,13 @@ impl CliExecutor {
 
     /// Terminates the child process via `start_kill()` (non-Unix).
     #[cfg(not(unix))]
-    fn terminate_child(child: &mut tokio::process::Child) {
-        let _ = child.start_kill();
-    }
+    fn terminate_child(child: &mut tokio::process::Child) { let _ = child.start_kill(); }
 
     /// Executes a prompt without streaming (captures all output).
     ///
     /// Uses no timeout by default. For timed execution, use
     /// `execute_capture_with_timeout`.
+    #[allow(dead_code)]
     pub async fn execute_capture(&self, prompt: &str) -> std::io::Result<ExecutionResult> {
         self.execute_capture_with_timeout(prompt, None).await
     }
@@ -299,12 +300,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_echo() {
         let backend = CliBackend {
-            command: "echo".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "echo".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -323,12 +324,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_stdin() {
         let backend = CliBackend {
-            command: "cat".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            command:       "cat".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -341,12 +342,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_failure() {
         let backend = CliBackend {
-            command: "false".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "false".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -360,12 +361,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_timeout() {
         let backend = CliBackend {
-            command: "sleep".to_string(),
-            args: vec!["10".to_string()],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            command:       "sleep".to_string(),
+            args:          vec!["10".to_string()],
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -385,12 +386,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_timeout_resets_on_output_activity() {
         let backend = CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -416,12 +417,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_streams_output_before_inactivity_timeout() {
         let backend = CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), "printf 'hello\\n'; sleep 10".to_string()],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string(), "printf 'hello\\n'; sleep 10".to_string()],
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -442,12 +443,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_no_timeout_when_fast() {
         let backend = CliBackend {
-            command: "echo".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "echo".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -465,15 +466,15 @@ mod tests {
     #[tokio::test]
     async fn test_stderr_not_mixed_into_output() {
         let backend = CliBackend {
-            command: "sh".to_string(),
-            args: vec![
+            command:       "sh".to_string(),
+            args:          vec![
                 "-c".to_string(),
                 "echo stdout_line; echo stderr_line >&2".to_string(),
             ],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,11 +3,19 @@
 //! This module provides a CLI-agnostic execution layer that can invoke
 //! various agent CLIs (Claude, Kiro, Gemini, Codex, etc.) with prompts
 //! and collect their output. Ported from ralph-orchestrator.
+//!
+//! Many items are kept for forward compatibility even if not yet used
+//! by tenki's current command set.
 
 pub mod backend;
 pub mod config;
 pub mod executor;
 
+#[allow(unused_imports)]
 pub use backend::{CliBackend, CommandSpec, OutputFormat, PromptMode};
-pub use config::{AgentConfig, ConfigPromptMode};
-pub use executor::{CliExecutor, ExecutionResult};
+pub use config::AgentConfig;
+#[allow(unused_imports)]
+pub use config::ConfigPromptMode;
+pub use executor::CliExecutor;
+#[allow(unused_imports)]
+pub use executor::ExecutionResult;

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -14,6 +14,8 @@ pub struct AppConfig {
     pub defaults: DefaultsConfig,
     /// Display preferences.
     pub display:  DisplayConfig,
+    /// Agent backend configuration.
+    pub agent:    crate::agent::AgentConfig,
 }
 
 /// Default values applied when creating new applications.

--- a/src/cli/analyze.rs
+++ b/src/cli/analyze.rs
@@ -1,0 +1,336 @@
+//! Analyze command — score job fit via agent CLI with keyword fallback.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    agent::{CliBackend, CliExecutor},
+    app_config,
+    db::Database,
+    error::{Result, TenkiError},
+};
+
+/// Analysis result returned to the caller.
+#[derive(Debug, Serialize)]
+struct AnalysisResult {
+    ok:        bool,
+    action:    &'static str,
+    id:        String,
+    score:     f64,
+    method:    String,
+    breakdown: serde_json::Value,
+    notes:     String,
+}
+
+/// Score breakdown from the LLM (5-criteria model).
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct ScoreBreakdown {
+    #[serde(default)]
+    skills:     f64,
+    #[serde(default)]
+    experience: f64,
+    #[serde(default)]
+    location:   f64,
+    #[serde(default)]
+    domain:     f64,
+    #[serde(default)]
+    growth:     f64,
+    #[serde(default)]
+    total:      f64,
+    #[serde(default)]
+    notes:      String,
+}
+
+/// Run the analyze command for a given application.
+pub async fn run(
+    db: &Database,
+    id: &str,
+    json: bool,
+    backend_override: Option<&str>,
+) -> Result<()> {
+    let app = db.get_application(id).await?;
+    let jd_text = app
+        .jd_text
+        .as_deref()
+        .ok_or_else(|| TenkiError::MissingJdText { id: id.to_string() })?;
+
+    // Try agent CLI scoring first, fall back to keyword matching
+    let (score, method, breakdown, notes) = match try_agent_scoring(
+        id,
+        &app.position,
+        jd_text,
+        app.skills.as_deref(),
+        backend_override,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("Agent scoring failed, falling back to keywords: {e}");
+            let (s, b) = keyword_scoring(jd_text, app.skills.as_deref());
+            let n = format!("Keyword fallback (agent failed: {e})");
+            (s, "keyword".to_string(), b, n)
+        }
+    };
+
+    // Persist score to DB
+    db.update_fitness(id, score, &notes).await?;
+
+    let result = AnalysisResult {
+        ok: true,
+        action: "analyze",
+        id: id.to_string(),
+        score,
+        method,
+        breakdown: serde_json::to_value(&breakdown).unwrap_or_default(),
+        notes,
+    };
+
+    if json {
+        println!("{}", serde_json::to_string(&result).unwrap_or_default());
+    } else {
+        eprintln!("Fitness score: {score:.0}/100 (method: {})", result.method);
+        eprintln!("Notes: {}", result.notes);
+    }
+
+    Ok(())
+}
+
+/// Build the scoring prompt for the agent CLI.
+fn build_prompt(position: &str, jd_text: &str, skills: Option<&str>) -> String {
+    let skills_section = skills
+        .map(|s| format!("\n\nCandidate skills: {s}"))
+        .unwrap_or_default();
+
+    format!(
+        r#"You are a job fit scoring engine. Analyze the candidate's fit for this role and return ONLY a JSON object (no markdown, no explanation).
+
+Position: {position}{skills_section}
+
+Job Description:
+{jd_text}
+
+Score each criterion (integer):
+- skills (0-30): How well candidate skills match required skills
+- experience (0-25): Experience level alignment
+- location (0-15): Location/remote compatibility
+- domain (0-15): Industry/domain relevance
+- growth (0-15): Career growth alignment
+
+Return exactly this JSON structure:
+{{"skills":0,"experience":0,"location":0,"domain":0,"growth":0,"total":0,"notes":"brief summary"}}"#
+    )
+}
+
+/// Try scoring via agent CLI backend.
+async fn try_agent_scoring(
+    _id: &str,
+    position: &str,
+    jd_text: &str,
+    skills: Option<&str>,
+    backend_override: Option<&str>,
+) -> std::result::Result<(f64, String, ScoreBreakdown, String), Box<dyn std::error::Error>> {
+    let cfg = app_config::load();
+    let backend_name = backend_override.unwrap_or(&cfg.agent.backend);
+
+    let backend = CliBackend::from_name(backend_name)?;
+    let executor = CliExecutor::new(backend);
+
+    let prompt = build_prompt(position, jd_text, skills);
+    let timeout = Duration::from_secs(u64::from(cfg.agent.idle_timeout_secs));
+    let result = executor
+        .execute_capture_with_timeout(&prompt, Some(timeout))
+        .await?;
+
+    if !result.success {
+        return Err(format!("agent exited with code {:?}", result.exit_code).into());
+    }
+
+    let breakdown: ScoreBreakdown = parse_json_from_output(&result.output)?;
+    let total = breakdown.total;
+    let notes = breakdown.notes.clone();
+
+    Ok((total, format!("agent:{backend_name}"), breakdown, notes))
+}
+
+/// Parse JSON from agent output, handling markdown fences and prefix text.
+fn parse_json_from_output(
+    output: &str,
+) -> std::result::Result<ScoreBreakdown, Box<dyn std::error::Error>> {
+    let trimmed = output.trim();
+
+    // Try direct parse first
+    if let Ok(v) = serde_json::from_str::<ScoreBreakdown>(trimmed) {
+        return Ok(v);
+    }
+
+    // Try extracting from markdown fences
+    if let Some(json_str) = extract_fenced_json(trimmed)
+        && let Ok(v) = serde_json::from_str::<ScoreBreakdown>(json_str)
+    {
+        return Ok(v);
+    }
+
+    // Try finding JSON object in the output (prefix text before JSON)
+    if let Some(start) = trimmed.find('{')
+        && let Some(end) = trimmed.rfind('}')
+    {
+        let candidate = &trimmed[start..=end];
+        if let Ok(v) = serde_json::from_str::<ScoreBreakdown>(candidate) {
+            return Ok(v);
+        }
+    }
+
+    Err(format!(
+        "could not parse JSON from agent output: {}",
+        &trimmed[..trimmed.len().min(200)]
+    )
+    .into())
+}
+
+/// Extract JSON content from markdown code fences.
+fn extract_fenced_json(text: &str) -> Option<&str> {
+    let start_markers = ["```json\n", "```json\r\n", "```\n", "```\r\n"];
+    for marker in &start_markers {
+        if let Some(start) = text.find(marker) {
+            let json_start = start + marker.len();
+            if let Some(end) = text[json_start..].find("```") {
+                return Some(text[json_start..json_start + end].trim());
+            }
+        }
+    }
+    None
+}
+
+/// Keyword-based scoring fallback when agent is unavailable.
+fn keyword_scoring(jd_text: &str, skills: Option<&str>) -> (f64, ScoreBreakdown) {
+    let jd_lower = jd_text.to_lowercase();
+    let skill_list: Vec<&str> = skills
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if skill_list.is_empty() {
+        let breakdown = ScoreBreakdown {
+            skills:     0.0,
+            experience: 12.0,
+            location:   8.0,
+            domain:     8.0,
+            growth:     8.0,
+            total:      36.0,
+            notes:      "No candidate skills provided — baseline score only".to_string(),
+        };
+        return (36.0, breakdown);
+    }
+
+    let matched: Vec<&str> = skill_list
+        .iter()
+        .filter(|skill| jd_lower.contains(&skill.to_lowercase()))
+        .copied()
+        .collect();
+
+    #[allow(clippy::cast_precision_loss)] // skill counts are tiny, no precision concern
+    let match_ratio = if skill_list.is_empty() {
+        0.0
+    } else {
+        matched.len() as f64 / skill_list.len() as f64
+    };
+
+    // Skills score: up to 30 based on match ratio
+    let skills_score = (match_ratio * 30.0).round();
+    // Other dimensions get baseline scores
+    let experience = 12.0;
+    let location = 8.0;
+    let domain = 8.0;
+    let growth = 8.0;
+    let total = skills_score + experience + location + domain + growth;
+
+    let notes = format!(
+        "Matched {}/{} skills: {}",
+        matched.len(),
+        skill_list.len(),
+        matched.join(", ")
+    );
+
+    let breakdown = ScoreBreakdown {
+        skills: skills_score,
+        experience,
+        location,
+        domain,
+        growth,
+        total,
+        notes,
+    };
+
+    (total, breakdown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_clean_json() {
+        let input = r#"{"skills":25,"experience":20,"location":10,"domain":12,"growth":10,"total":77,"notes":"good fit"}"#;
+        let result = parse_json_from_output(input).unwrap();
+        assert!((result.total - 77.0).abs() < f64::EPSILON);
+        assert_eq!(result.notes, "good fit");
+    }
+
+    #[test]
+    fn test_parse_fenced_json() {
+        let input = "Here is the \
+                     analysis:\n```json\n{\"skills\":20,\"experience\":15,\"location\":10,\"\
+                     domain\":10,\"growth\":10,\"total\":65,\"notes\":\"decent\"}\n```\n";
+        let result = parse_json_from_output(input).unwrap();
+        assert!((result.total - 65.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_prefix_text_before_json() {
+        let input = "Based on my analysis, the score is: \
+                     {\"skills\":15,\"experience\":10,\"location\":5,\"domain\":8,\"growth\":7,\"\
+                     total\":45,\"notes\":\"ok\"}";
+        let result = parse_json_from_output(input).unwrap();
+        assert!((result.total - 45.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_invalid_output() {
+        let input = "I cannot parse this as JSON at all";
+        assert!(parse_json_from_output(input).is_err());
+    }
+
+    #[test]
+    fn test_keyword_scoring_with_matches() {
+        let jd = "We need Rust, Python, and TypeScript experience with Docker and Kubernetes";
+        let skills = Some("Rust, Python, Go, Docker");
+        let (score, breakdown) = keyword_scoring(jd, skills);
+        // 3/4 skills match -> 22.5 rounded to 23 + baselines (12+8+8+8) = 59
+        assert!((breakdown.skills - 23.0).abs() < f64::EPSILON);
+        assert!((score - 59.0).abs() < f64::EPSILON);
+        assert!(breakdown.notes.contains("3/4"));
+    }
+
+    #[test]
+    fn test_keyword_scoring_no_skills() {
+        let jd = "Looking for a Rust developer";
+        let (score, breakdown) = keyword_scoring(jd, None);
+        assert!((score - 36.0).abs() < f64::EPSILON);
+        assert!(breakdown.notes.contains("No candidate skills"));
+    }
+
+    #[test]
+    fn test_keyword_scoring_no_matches() {
+        let jd = "Looking for a Java developer with Spring Boot";
+        let skills = Some("Rust, Python, Go");
+        let (score, breakdown) = keyword_scoring(jd, skills);
+        assert!((breakdown.skills - 0.0).abs() < f64::EPSILON);
+        assert!((score - 36.0).abs() < f64::EPSILON);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod analyze;
 pub mod app;
 pub mod export;
 pub mod interview;
@@ -37,10 +38,16 @@ pub enum Command {
     /// Track application stage transitions (set, list)
     #[command(subcommand)]
     Stage(StageCommand),
-    /// Analyze job fit (not yet implemented)
+    /// Analyze job fit using AI agent
     Analyze {
         /// Application ID (8-char prefix or full UUID)
-        id: String,
+        id:      String,
+        /// Output as JSON
+        #[arg(long)]
+        json:    bool,
+        /// Override agent backend (e.g., "claude", "gemini")
+        #[arg(long)]
+        backend: Option<String>,
     },
     /// Tailor resume for a job (not yet implemented)
     Tailor {
@@ -211,6 +218,9 @@ pub enum AppCommand {
         /// New source
         #[arg(long)]
         source:    Option<String>,
+        /// Skills (comma-separated)
+        #[arg(long)]
+        skills:    Option<String>,
         /// New notes
         #[arg(long)]
         notes:     Option<String>,

--- a/src/db/application.rs
+++ b/src/db/application.rs
@@ -269,7 +269,6 @@ impl Database {
     }
 
     /// Update fitness score and notes for an application.
-    #[allow(dead_code)]
     pub async fn update_fitness(&self, id: &str, score: f64, notes: &str) -> Result<()> {
         let result = sqlx::query(
             "UPDATE applications SET fitness_score = ?1, fitness_notes = ?2, updated_at = \

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,14 @@ pub enum TenkiError {
 
     #[snafu(display("invalid URL: {input} — expected http:// or https://"))]
     InvalidUrl { input: String },
+
+    #[snafu(display("LLM analysis failed: {message}"))]
+    LlmAnalysis { message: String },
+
+    #[snafu(display(
+        "missing JD text for application {id} — cannot analyze without job description"
+    ))]
+    MissingJdText { id: String },
 }
 
 pub type Result<T> = std::result::Result<T, TenkiError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod app_config;
 pub mod db;
 pub mod domain;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agent;
 mod app_config;
 mod cli;
 mod db;
@@ -117,6 +118,7 @@ async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 job_level,
                 is_remote,
                 source,
+                skills,
                 notes,
                 json,
             } => {
@@ -133,6 +135,7 @@ async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
                     .maybe_job_level(job_level_str.as_deref())
                     .maybe_is_remote(is_remote)
                     .maybe_source(source.as_deref())
+                    .maybe_skills(skills.as_deref())
                     .maybe_notes(notes.as_deref())
                     .build();
                 cli::app::update(&db, &id, status, outcome, stage, &params, json).await?;
@@ -251,8 +254,9 @@ async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 cli::stage::list(&db, &app_id, json).await?;
             }
         },
-        Command::Analyze { id } => {
-            eprintln!("analyze not yet implemented (app: {id})");
+        Command::Analyze { id, json, backend } => {
+            let full_id = db.resolve_app_id(&id).await?;
+            cli::analyze::run(&db, &full_id, json, backend.as_deref()).await?;
         }
         Command::Tailor { id } => {
             eprintln!("tailor not yet implemented (app: {id})");
@@ -318,6 +322,10 @@ fn set_config_field(cfg: &mut app_config::AppConfig, key: &str, value: &str) {
         "defaults.status" => cfg.defaults.status = value.to_string(),
         "defaults.source" => cfg.defaults.source = Some(value.to_string()),
         "display.date_format" => cfg.display.date_format = value.to_string(),
+        "agent.backend" => cfg.agent.backend = value.to_string(),
+        "agent.idle_timeout_secs" => {
+            cfg.agent.idle_timeout_secs = value.parse().unwrap_or(30);
+        }
         _ => eprintln!("warning: unknown config key: {key}"),
     }
 }
@@ -328,6 +336,8 @@ fn get_config_field(cfg: &app_config::AppConfig, key: &str) -> Option<String> {
         "defaults.status" => Some(cfg.defaults.status.clone()),
         "defaults.source" => cfg.defaults.source.clone(),
         "display.date_format" => Some(cfg.display.date_format.clone()),
+        "agent.backend" => Some(cfg.agent.backend.clone()),
+        "agent.idle_timeout_secs" => Some(cfg.agent.idle_timeout_secs.to_string()),
         _ => None,
     }
 }
@@ -343,6 +353,11 @@ fn config_as_map(cfg: &app_config::AppConfig) -> Vec<(String, String)> {
         (
             "display.date_format".to_string(),
             cfg.display.date_format.clone(),
+        ),
+        ("agent.backend".to_string(), cfg.agent.backend.clone()),
+        (
+            "agent.idle_timeout_secs".to_string(),
+            cfg.agent.idle_timeout_secs.to_string(),
         ),
     ]
 }

--- a/tests/cli_analyze.rs
+++ b/tests/cli_analyze.rs
@@ -1,0 +1,95 @@
+//! Integration tests for the `analyze` command.
+
+mod common;
+
+use common::{tenki_initialized, tenki_with};
+use predicates::prelude::*;
+
+#[test]
+fn analyze_keyword_fallback() {
+    let tmp = tenki_initialized();
+
+    // Add an application with JD text
+    let output = tenki_with(&tmp)
+        .args([
+            "app",
+            "add",
+            "--company",
+            "Acme Corp",
+            "--position",
+            "Rust Developer",
+            "--jd-text",
+            "We need experience in Rust, Python, Docker, and Kubernetes for backend services",
+            "--json",
+        ])
+        .output()
+        .expect("add app");
+    assert!(output.status.success(), "add app failed");
+
+    let add_json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse add json");
+    let id = add_json["id"].as_str().expect("id field");
+    let short_id = &id[..8];
+
+    // Update with skills
+    tenki_with(&tmp)
+        .args([
+            "app",
+            "update",
+            short_id,
+            "--skills",
+            "Rust, Python, Go, Docker",
+        ])
+        .assert()
+        .success();
+
+    // Analyze with --json (should fall back to keyword scoring since no agent CLI
+    // is available)
+    let output = tenki_with(&tmp)
+        .args(["analyze", short_id, "--json"])
+        .output()
+        .expect("analyze");
+    assert!(output.status.success(), "analyze failed: {output:?}");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse analyze json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["action"], "analyze");
+    assert_eq!(json["method"], "keyword");
+    assert!(
+        json["score"].as_f64().expect("score") > 0.0,
+        "score should be positive"
+    );
+}
+
+#[test]
+fn analyze_missing_jd_error() {
+    let tmp = tenki_initialized();
+
+    // Add an application without JD text
+    let output = tenki_with(&tmp)
+        .args([
+            "app",
+            "add",
+            "--company",
+            "NoJD Inc",
+            "--position",
+            "Engineer",
+            "--json",
+        ])
+        .output()
+        .expect("add app");
+    assert!(output.status.success());
+
+    let add_json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse add json");
+    let id = add_json["id"].as_str().expect("id field");
+    let short_id = &id[..8];
+
+    // Analyze should fail with missing JD error
+    tenki_with(&tmp)
+        .args(["analyze", short_id, "--json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("missing JD text"));
+}


### PR DESCRIPTION
## Summary
- Sync `agent/` module from cli-template upstream (supports Claude, Gemini, Codex, Kiro, and 6+ other agent backends)
- Implement `tenki analyze <id>` using agent CLI for LLM-based job fit scoring (0-100, job-ops 5-criteria prompt)
- Automatic fallback to keyword-based scoring when agent CLI unavailable
- Add `[agent]` config section (backend, idle_timeout_secs) to AppConfig
- Add `--backend` flag for runtime agent override (e.g., `--backend gemini`)
- Add `--skills` flag to `app update`

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 36/36 tests pass
- [x] Keyword fallback path tested end-to-end
- [x] Missing JD text error tested

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)