### PR TITLE
docs: add doc comments to all public items (#23)

### DIFF
--- a/src/domain/enums.rs
+++ b/src/domain/enums.rs
@@ -21,6 +21,7 @@ pub enum AppStatus {
 }
 
 impl AppStatus {
+    /// Returns the lowercase string representation of this status.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -74,6 +75,7 @@ pub enum InterviewType {
 }
 
 impl InterviewType {
+    /// Returns the kebab-case string representation of this interview type.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -101,6 +103,7 @@ pub enum InterviewStatus {
 }
 
 impl InterviewStatus {
+    /// Returns the lowercase string representation of this interview status.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -131,6 +134,7 @@ pub enum Outcome {
 }
 
 impl Outcome {
+    /// Returns the `snake_case` string representation of this outcome.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -183,6 +187,7 @@ pub enum Stage {
 }
 
 impl Stage {
+    /// Returns the `snake_case` string representation of this stage.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -235,6 +240,7 @@ pub enum JobType {
 }
 
 impl JobType {
+    /// Returns the `snake_case` string representation of this job type.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -279,6 +285,7 @@ pub enum JobLevel {
 }
 
 impl JobLevel {
+    /// Returns the lowercase string representation of this job level.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -327,6 +334,7 @@ pub enum TaskType {
 }
 
 impl TaskType {
+    /// Returns the `snake_case` string representation of this task type.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -369,6 +377,7 @@ pub enum InterviewOutcome {
 }
 
 impl InterviewOutcome {
+    /// Returns the lowercase string representation of this interview outcome.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 
 use snafu::Snafu;
 
+/// Top-level error type for the tenki application.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum TenkiError {
@@ -53,4 +54,5 @@ pub enum TenkiError {
     MissingJdText { id: String },
 }
 
+/// Convenience result type for tenki operations.
 pub type Result<T> = std::result::Result<T, TenkiError>;

--- a/src/store/config.rs
+++ b/src/store/config.rs
@@ -4,8 +4,10 @@ use sqlx::sqlite::SqlitePoolOptions;
 
 use super::{db::DBStore, err::Result};
 
+/// `SQLite` connection pool configuration.
 #[derive(Debug, Clone, bon::Builder, serde::Serialize, serde::Deserialize)]
 pub struct DatabaseConfig {
+    /// Maximum number of connections in the pool (default: 5).
     #[serde(default = "default_max_connections")]
     #[builder(default = 5, getter)]
     pub max_connections: u32,
@@ -14,6 +16,7 @@ pub struct DatabaseConfig {
 const fn default_max_connections() -> u32 { 5 }
 
 impl DatabaseConfig {
+    /// Opens a `SQLite` connection pool with WAL mode and foreign keys enabled.
     pub async fn open(&self, database_url: &str) -> Result<DBStore> {
         let pool = SqlitePoolOptions::new()
             .max_connections(self.max_connections)

--- a/src/store/db.rs
+++ b/src/store/db.rs
@@ -4,16 +4,20 @@ use sqlx::{Sqlite, SqlitePool};
 
 use super::err::Result;
 
+/// Thin wrapper around a `SQLite` connection pool.
 #[derive(Clone)]
 pub struct DBStore {
     pool: SqlitePool,
 }
 
 impl DBStore {
+    /// Creates a new store from an existing connection pool.
     pub const fn new(pool: SqlitePool) -> Self { Self { pool } }
 
+    /// Returns a reference to the underlying connection pool.
     pub const fn pool(&self) -> &SqlitePool { &self.pool }
 
+    /// Acquires a single connection from the pool.
     pub async fn acquire(&self) -> Result<sqlx::pool::PoolConnection<Sqlite>> {
         Ok(self.pool.acquire().await?)
     }

--- a/src/store/err.rs
+++ b/src/store/err.rs
@@ -2,8 +2,10 @@
 
 use snafu::Snafu;
 
+/// Convenience result type for store operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Errors originating from the database store layer.
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub))]
 pub enum Error {


### PR DESCRIPTION
## Summary
- Added English `///` doc comments to all public items across the codebase
- Covers: error types, path helpers, config structs, agent module, CLI structs, domain enums, store module

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)