### PR TITLE
test: add integration tests for stage, task, and export commands (#24)

### DIFF
--- a/tests/cli_export.rs
+++ b/tests/cli_export.rs
@@ -1,0 +1,120 @@
+mod common;
+use predicates::prelude::*;
+
+#[test]
+fn export_without_flags_prints_usage_hint() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Export without --typ or --pdf should hint to specify a format
+    common::tenki_with(&tmp)
+        .args(["export", app_id])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("--typ").or(predicate::str::contains("--pdf")));
+}
+
+#[test]
+fn export_typ_no_resume_stored() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args([
+            "app",
+            "add",
+            "--company",
+            "Acme",
+            "--position",
+            "SRE",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Export typ when no resume is stored — should succeed but print message
+    common::tenki_with(&tmp)
+        .args(["export", app_id, "--typ"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No resume typ found"));
+}
+
+#[test]
+fn export_pdf_no_resume_stored() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args([
+            "app",
+            "add",
+            "--company",
+            "Acme",
+            "--position",
+            "SRE",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Export pdf when no resume is stored — should succeed but print message
+    common::tenki_with(&tmp)
+        .args(["export", app_id, "--pdf"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No resume pdf found"));
+}
+
+#[test]
+fn export_typ_after_import() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args([
+            "app",
+            "add",
+            "--company",
+            "Acme",
+            "--position",
+            "SRE",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Create a temporary typ file and import it
+    let typ_path = tmp.path().join("resume.typ");
+    std::fs::write(&typ_path, "#set page(paper: \"a4\")\nHello World").expect("write typ");
+
+    common::tenki_with(&tmp)
+        .args(["import", app_id, "--typ", typ_path.to_str().expect("path")])
+        .assert()
+        .success();
+
+    // Export should now produce a file
+    let out_path = tmp.path().join("exported.typ");
+    common::tenki_with(&tmp)
+        .args([
+            "export",
+            app_id,
+            "--typ",
+            "-o",
+            out_path.to_str().expect("path"),
+        ])
+        .assert()
+        .success();
+
+    // Verify the exported file exists and has content
+    let content = std::fs::read_to_string(&out_path).expect("read exported typ");
+    assert!(
+        content.contains("Hello World"),
+        "exported typ should contain imported content"
+    );
+}

--- a/tests/cli_stage.rs
+++ b/tests/cli_stage.rs
@@ -2,6 +2,62 @@ mod common;
 use predicates::prelude::*;
 
 #[test]
+fn stage_set_returns_json_with_expected_fields() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Set stage and verify JSON fields
+    let out = common::tenki_with(&tmp)
+        .args(["stage", "set", app_id, "applied", "--json"])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse json");
+    assert!(v.get("id").is_some(), "response should contain 'id'");
+    assert!(
+        v.get("stage").is_some() || v.get("current_stage").is_some(),
+        "response should contain stage info"
+    );
+}
+
+#[test]
+fn stage_set_with_note() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Set stage with note
+    common::tenki_with(&tmp)
+        .args([
+            "stage",
+            "set",
+            app_id,
+            "recruiter-screen",
+            "--note",
+            "Passed initial review",
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    // Verify note appears in list
+    common::tenki_with(&tmp)
+        .args(["stage", "list", app_id, "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Passed initial review"));
+}
+
+#[test]
 fn stage_transitions() {
     let tmp = common::tenki_initialized();
     let out = common::tenki_with(&tmp)
@@ -36,4 +92,65 @@ fn stage_transitions() {
         .assert()
         .success()
         .stdout(predicate::str::contains("technical"));
+}
+
+#[test]
+fn stage_list_shows_full_history() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Transition through multiple stages
+    common::tenki_with(&tmp)
+        .args(["stage", "set", app_id, "applied", "--json"])
+        .assert()
+        .success();
+    common::tenki_with(&tmp)
+        .args(["stage", "set", app_id, "recruiter-screen", "--json"])
+        .assert()
+        .success();
+    common::tenki_with(&tmp)
+        .args(["stage", "set", app_id, "technical", "--json"])
+        .assert()
+        .success();
+    common::tenki_with(&tmp)
+        .args(["stage", "set", app_id, "offer", "--json"])
+        .assert()
+        .success();
+
+    // List should contain all stages
+    let out = common::tenki_with(&tmp)
+        .args(["stage", "list", app_id, "--json"])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("applied"), "should contain applied");
+    assert!(
+        stdout.contains("recruiter_screen"),
+        "should contain recruiter_screen"
+    );
+    assert!(stdout.contains("technical"), "should contain technical");
+    assert!(stdout.contains("offer"), "should contain offer");
+}
+
+#[test]
+fn stage_set_rejects_invalid_stage() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Invalid stage value should fail (clap validation)
+    common::tenki_with(&tmp)
+        .args(["stage", "set", app_id, "nonexistent-stage", "--json"])
+        .assert()
+        .failure();
 }

--- a/tests/cli_task.rs
+++ b/tests/cli_task.rs
@@ -2,6 +2,35 @@ mod common;
 use predicates::prelude::*;
 
 #[test]
+fn task_add_returns_json_with_id() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Add task and verify JSON contains id
+    let out = common::tenki_with(&tmp)
+        .args([
+            "task",
+            "add",
+            "--app-id",
+            app_id,
+            "--type",
+            "todo",
+            "Send thank-you email",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse json");
+    assert!(v.get("id").is_some(), "response should contain 'id'");
+}
+
+#[test]
 fn task_lifecycle() {
     let tmp = common::tenki_initialized();
     let out = common::tenki_with(&tmp)
@@ -46,4 +75,167 @@ fn task_lifecycle() {
         .args(["task", "delete", tid, "--json"])
         .assert()
         .success();
+}
+
+#[test]
+fn task_update_reflected_in_list() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Add task
+    let out = common::tenki_with(&tmp)
+        .args([
+            "task",
+            "add",
+            "--app-id",
+            app_id,
+            "--type",
+            "todo",
+            "Original title",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let tid = &v["id"].as_str().expect("id")[..8];
+
+    // Update title and add notes
+    common::tenki_with(&tmp)
+        .args([
+            "task",
+            "update",
+            tid,
+            "--title",
+            "Updated title",
+            "--notes",
+            "Some extra context",
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    // Verify update is reflected in list
+    common::tenki_with(&tmp)
+        .args(["task", "list", app_id, "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Updated title"));
+}
+
+#[test]
+fn task_add_with_due_date() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Add task with due date
+    let out = common::tenki_with(&tmp)
+        .args([
+            "task",
+            "add",
+            "--app-id",
+            app_id,
+            "--type",
+            "follow-up",
+            "--due-date",
+            "2026-04-01",
+            "Follow up with recruiter",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse json");
+    assert!(v.get("id").is_some(), "response should contain 'id'");
+
+    // Verify due date and title appear in list
+    common::tenki_with(&tmp)
+        .args(["task", "list", app_id, "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Follow up with recruiter"))
+        .stdout(predicate::str::contains("2026-04-01"));
+}
+
+#[test]
+fn task_done_reflected_in_list() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Add task
+    let out = common::tenki_with(&tmp)
+        .args([
+            "task",
+            "add",
+            "--app-id",
+            app_id,
+            "--type",
+            "prep",
+            "Practice coding",
+            "--json",
+        ])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let tid = &v["id"].as_str().expect("id")[..8];
+
+    // Mark done
+    common::tenki_with(&tmp)
+        .args(["task", "done", tid, "--json"])
+        .assert()
+        .success();
+
+    // Verify is_completed is true in list output
+    common::tenki_with(&tmp)
+        .args(["task", "list", app_id, "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"is_completed\":true"));
+}
+
+#[test]
+fn task_list_all_pending() {
+    let tmp = common::tenki_initialized();
+    let out = common::tenki_with(&tmp)
+        .args(["app", "add", "--company", "X", "--position", "Y", "--json"])
+        .output()
+        .expect("run");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse");
+    let app_id = &v["id"].as_str().expect("id")[..8];
+
+    // Add two tasks
+    common::tenki_with(&tmp)
+        .args([
+            "task", "add", "--app-id", app_id, "--type", "todo", "Task A", "--json",
+        ])
+        .assert()
+        .success();
+    common::tenki_with(&tmp)
+        .args([
+            "task", "add", "--app-id", app_id, "--type", "prep", "Task B", "--json",
+        ])
+        .assert()
+        .success();
+
+    // List without app_id filter (all pending)
+    common::tenki_with(&tmp)
+        .args(["task", "list", "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Task A"))
+        .stdout(predicate::str::contains("Task B"));
 }


### PR DESCRIPTION
## Summary
- Added integration tests for `tenki stage` (set, show)
- Added integration tests for `tenki task` (add, list, update, done)
- Added integration tests for `tenki export` (basic execution)
- All tests use `TENKI_DATA_DIR` for isolation

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)