### PR TITLE
fix(cli): replace silent unwrap_or_default with proper error propagation (#28)

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -61,8 +61,17 @@ pub fn load() -> &'static AppConfig {
             let settings = config::Config::builder()
                 .add_source(config::File::from(path.as_ref()))
                 .build()
-                .unwrap_or_default();
-            settings.try_deserialize().unwrap_or_default()
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        "failed to load config from {}: {e}, using defaults",
+                        path.display()
+                    );
+                    config::Config::default()
+                });
+            settings.try_deserialize().unwrap_or_else(|e| {
+                tracing::warn!("failed to parse config: {e}, using defaults");
+                AppConfig::default()
+            })
         } else {
             AppConfig::default()
         }

--- a/src/cli/analyze.rs
+++ b/src/cli/analyze.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
 
 use crate::{
     agent::{CliBackend, CliExecutor},
@@ -83,12 +84,15 @@ pub async fn run(
         id: id.to_string(),
         score,
         method,
-        breakdown: serde_json::to_value(&breakdown).unwrap_or_default(),
+        breakdown: serde_json::to_value(&breakdown).context(crate::error::JsonSnafu)?,
         notes,
     };
 
     if json {
-        println!("{}", serde_json::to_string(&result).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string(&result).context(crate::error::JsonSnafu)?
+        );
     } else {
         eprintln!("Fitness score: {score:.0}/100 (method: {})", result.method);
         eprintln!("Notes: {}", result.notes);

--- a/src/cli/tailor.rs
+++ b/src/cli/tailor.rs
@@ -4,6 +4,7 @@
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
 
 use crate::{
     agent::{CliBackend, CliExecutor},
@@ -88,7 +89,10 @@ pub async fn run(
     };
 
     if json {
-        println!("{}", serde_json::to_string(&result).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string(&result).context(crate::error::JsonSnafu)?
+        );
     } else {
         eprintln!("Tailored resume content (method: {}):", result.method);
         eprintln!("  Headline: {}", result.headline);


### PR DESCRIPTION
## Summary
- Replaced `serde_json` `unwrap_or_default()` calls with `?` error propagation in analyze.rs and tailor.rs
- Added `tracing::warn!` for config load failures before falling back to defaults
- CLI now surfaces serialization errors instead of silently returning empty strings

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)