### PR TITLE
fix(agent): replace invalid --yolo with --full-auto for codex backend (#25)

### DIFF
--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -170,7 +170,7 @@ impl CliBackend {
     fn codex() -> Self {
         Self {
             command:       "codex".to_string(),
-            args:          vec!["exec".to_string(), "--yolo".to_string()],
+            args:          vec!["exec".to_string(), "--full-auto".to_string()],
             prompt_mode:   PromptMode::Arg,
             prompt_flag:   None,
             output_format: OutputFormat::Text,


### PR DESCRIPTION
Closes https://github.com/rararulab/cli-template/issues/25

## Summary
- Replace invalid `--yolo` flag with `--full-auto` in codex backend definition
- `--yolo` doesn't exist in current codex CLI, causing all agent operations to exit with code 1
- This fixes pipeline scoring, tailoring, and export falling back to keyword matching

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] Run `tenki pipeline run` and verify agent scoring completes without fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)