### PR TITLE
fix(pipeline): stream-json parsing, discover resilience, and export validation (#52)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -10,7 +10,9 @@
 pub mod backend;
 pub mod config;
 pub mod executor;
+pub mod output;
 
 pub use backend::CliBackend;
 pub use config::AgentConfig;
 pub use executor::CliExecutor;
+pub use output::{extract_fenced_json, extract_result_from_stream_json};

--- a/src/agent/output.rs
+++ b/src/agent/output.rs
@@ -1,0 +1,82 @@
+//! Shared output parsing utilities for agent CLI responses.
+//!
+//! When backends emit stream-json (NDJSON), system/hook event lines precede
+//! the actual assistant response. These helpers extract the meaningful result
+//! so that downstream JSON parsing is not confused by framework events.
+
+/// Extract the final result text from Claude stream-json NDJSON output.
+///
+/// Stream-json output contains one JSON event per line. System/hook events
+/// (e.g. `{"type":"system","subtype":"hook_started",...}`) appear before the
+/// actual assistant response. The result lives in a line with
+/// `{"type":"result","result":"<text>"}`. Returns `None` if the output does
+/// not look like NDJSON stream-json, or if stream events are present but no
+/// result line was found.
+pub fn extract_result_from_stream_json(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let line = line.trim();
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line)
+            && v.get("type").and_then(serde_json::Value::as_str) == Some("result")
+        {
+            return v
+                .get("result")
+                .and_then(serde_json::Value::as_str)
+                .map(String::from);
+        }
+    }
+    // No result line found — return None so callers fall back to raw output.
+    None
+}
+
+/// Extract JSON content from markdown code fences.
+pub fn extract_fenced_json(text: &str) -> Option<&str> {
+    let start_markers = ["```json\n", "```json\r\n", "```\n", "```\r\n"];
+    for marker in &start_markers {
+        if let Some(start) = text.find(marker) {
+            let json_start = start + marker.len();
+            if let Some(end) = text[json_start..].find("```") {
+                return Some(text[json_start..json_start + end].trim());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_stream_json_with_result() {
+        let input = r#"{"type":"system","subtype":"hook_started","hook_id":"abc"}
+{"type":"system","subtype":"hook_completed","hook_id":"abc"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"here is the score"}]}}
+{"type":"result","result":"{\"key\":\"value\"}","subtype":"success"}"#;
+        let result = extract_result_from_stream_json(input);
+        assert_eq!(result, Some(r#"{"key":"value"}"#.to_string()));
+    }
+
+    #[test]
+    fn test_extract_stream_json_no_result_returns_none() {
+        let input = r#"{"type":"system","subtype":"hook_started","hook_id":"abc"}
+{"type":"system","subtype":"hook_completed","hook_id":"abc"}"#;
+        assert!(extract_result_from_stream_json(input).is_none());
+    }
+
+    #[test]
+    fn test_extract_stream_json_plain_text_returns_none() {
+        let input = "Just some plain text output with no NDJSON";
+        assert!(extract_result_from_stream_json(input).is_none());
+    }
+
+    #[test]
+    fn test_extract_fenced_json() {
+        let input = "Here:\n```json\n{\"a\":1}\n```\n";
+        assert_eq!(extract_fenced_json(input), Some("{\"a\":1}"));
+    }
+
+    #[test]
+    fn test_extract_fenced_json_none() {
+        assert!(extract_fenced_json("no fences here").is_none());
+    }
+}

--- a/src/cli/analyze.rs
+++ b/src/cli/analyze.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use crate::{
-    agent::{CliBackend, CliExecutor},
+    agent::{self, CliBackend, CliExecutor},
     app_config,
     db::Database,
     error::{Result, TenkiError},
@@ -211,7 +211,8 @@ fn parse_json_from_output(
 ) -> std::result::Result<ScoreBreakdown, Box<dyn std::error::Error>> {
     // When the backend emits stream-json (NDJSON), extract the result text first
     // so that system/hook event lines don't confuse downstream parsing.
-    let effective = extract_result_from_stream_json(output).unwrap_or_else(|| output.to_string());
+    let effective =
+        agent::extract_result_from_stream_json(output).unwrap_or_else(|| output.to_string());
     let trimmed = effective.trim();
 
     // Try direct parse first
@@ -220,7 +221,7 @@ fn parse_json_from_output(
     }
 
     // Try extracting from markdown fences
-    if let Some(json_str) = extract_fenced_json(trimmed)
+    if let Some(json_str) = agent::extract_fenced_json(trimmed)
         && let Ok(v) = serde_json::from_str::<ScoreBreakdown>(json_str)
     {
         return Ok(v);
@@ -241,52 +242,6 @@ fn parse_json_from_output(
         &trimmed[..trimmed.len().min(200)]
     )
     .into())
-}
-
-/// Extract the final result text from Claude stream-json NDJSON output.
-///
-/// Stream-json output contains one JSON event per line. System/hook events
-/// (e.g. `{"type":"system","subtype":"hook_started",...}`) appear before the
-/// actual assistant response. The result lives in a line with
-/// `{"type":"result","result":"<text>"}`. Returns `None` if the output does
-/// not look like NDJSON stream-json.
-fn extract_result_from_stream_json(output: &str) -> Option<String> {
-    let mut found_stream_event = false;
-    for line in output.lines() {
-        let line = line.trim();
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
-            if v.get("type").and_then(serde_json::Value::as_str).is_some() {
-                found_stream_event = true;
-            }
-            if v.get("type").and_then(serde_json::Value::as_str) == Some("result") {
-                return v
-                    .get("result")
-                    .and_then(serde_json::Value::as_str)
-                    .map(String::from);
-            }
-        }
-    }
-    // If we saw stream events but no result line, return empty to avoid
-    // misinterpreting hook JSON as scoring output.
-    if found_stream_event {
-        Some(String::new())
-    } else {
-        None
-    }
-}
-
-/// Extract JSON content from markdown code fences.
-fn extract_fenced_json(text: &str) -> Option<&str> {
-    let start_markers = ["```json\n", "```json\r\n", "```\n", "```\r\n"];
-    for marker in &start_markers {
-        if let Some(start) = text.find(marker) {
-            let json_start = start + marker.len();
-            if let Some(end) = text[json_start..].find("```") {
-                return Some(text[json_start..json_start + end].trim());
-            }
-        }
-    }
-    None
 }
 
 /// Keyword-based scoring fallback when agent is unavailable.
@@ -433,15 +388,10 @@ mod tests {
 
     #[test]
     fn test_parse_stream_json_no_result_line() {
-        // Stream events present but no result line — should not misparse hook JSON
+        // Stream events present but no result line — falls back to raw output
+        // which is not valid ScoreBreakdown JSON, so parsing fails.
         let input = r#"{"type":"system","subtype":"hook_started","hook_id":"abc"}
 {"type":"system","subtype":"hook_completed","hook_id":"abc"}"#;
         assert!(parse_json_from_output(input).is_err());
-    }
-
-    #[test]
-    fn test_extract_result_from_stream_json_returns_none_for_plain_text() {
-        let input = "Just some plain text output with no NDJSON";
-        assert!(extract_result_from_stream_json(input).is_none());
     }
 }

--- a/src/cli/resume_export.rs
+++ b/src/cli/resume_export.rs
@@ -87,6 +87,14 @@ Edit the resume source files to match this job. Keep formatting intact. Be conci
         });
     }
 
+    // Verify the agent actually modified files before building
+    if !has_git_changes(repo) {
+        let _ = git_restore(repo);
+        return Err(TenkiError::BuildCommandFailed {
+            message: "agent produced no file changes in resume repo".to_string(),
+        });
+    }
+
     // Step 2: Run build command to generate PDF
     let build_output = std::process::Command::new("sh")
         .arg("-c")
@@ -117,6 +125,16 @@ Edit the resume source files to match this job. Keep formatting intact. Be conci
     git_restore(repo)?;
 
     Ok(())
+}
+
+/// Check whether the resume repo has uncommitted changes (i.e. the agent edited files).
+fn has_git_changes(repo: &Path) -> bool {
+    std::process::Command::new("git")
+        .args(["diff", "--stat"])
+        .current_dir(repo)
+        .output()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
 }
 
 /// Restore the resume repo to a clean state via `git checkout .`.

--- a/src/cli/resume_export.rs
+++ b/src/cli/resume_export.rs
@@ -127,7 +127,8 @@ Edit the resume source files to match this job. Keep formatting intact. Be conci
     Ok(())
 }
 
-/// Check whether the resume repo has uncommitted changes (i.e. the agent edited files).
+/// Check whether the resume repo has uncommitted changes (i.e. the agent edited
+/// files).
 fn has_git_changes(repo: &Path) -> bool {
     std::process::Command::new("git")
         .args(["diff", "--stat"])

--- a/src/cli/tailor.rs
+++ b/src/cli/tailor.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use crate::{
-    agent::{CliBackend, CliExecutor},
+    agent::{self, CliBackend, CliExecutor},
     app_config,
     db::Database,
     error::{Result, TenkiError},
@@ -219,11 +219,16 @@ async fn try_agent_tailoring(
     ))
 }
 
-/// Parse JSON from agent output, handling markdown fences and prefix text.
+/// Parse JSON from agent output, handling stream-json NDJSON, markdown fences,
+/// and prefix text.
 fn parse_json_from_output(
     output: &str,
 ) -> std::result::Result<TailoringResponse, Box<dyn std::error::Error>> {
-    let trimmed = output.trim();
+    // When the backend emits stream-json (NDJSON), extract the result text first
+    // so that system/hook event lines don't confuse downstream parsing.
+    let effective =
+        agent::extract_result_from_stream_json(output).unwrap_or_else(|| output.to_string());
+    let trimmed = effective.trim();
 
     // Try direct parse first
     if let Ok(v) = serde_json::from_str::<TailoringResponse>(trimmed) {
@@ -231,7 +236,7 @@ fn parse_json_from_output(
     }
 
     // Try extracting from markdown fences
-    if let Some(json_str) = extract_fenced_json(trimmed)
+    if let Some(json_str) = agent::extract_fenced_json(trimmed)
         && let Ok(v) = serde_json::from_str::<TailoringResponse>(json_str)
     {
         return Ok(v);
@@ -252,20 +257,6 @@ fn parse_json_from_output(
         &trimmed[..trimmed.len().min(200)]
     )
     .into())
-}
-
-/// Extract JSON content from markdown code fences.
-fn extract_fenced_json(text: &str) -> Option<&str> {
-    let start_markers = ["```json\n", "```json\r\n", "```\n", "```\r\n"];
-    for marker in &start_markers {
-        if let Some(start) = text.find(marker) {
-            let json_start = start + marker.len();
-            if let Some(end) = text[json_start..].find("```") {
-                return Some(text[json_start..json_start + end].trim());
-            }
-        }
-    }
-    None
 }
 
 /// Keyword-based tailoring fallback when the agent is unavailable.
@@ -383,6 +374,17 @@ mod tests {
         assert_eq!(result.headline, "Rust Developer | FooCorp");
         assert!(result.skills.is_empty());
         assert!(result.summary.contains("FooCorp"));
+    }
+
+    #[test]
+    fn test_parse_stream_json_with_hook_events() {
+        let input = r#"{"type":"system","subtype":"hook_started","hook_id":"abc","hook_name":"SessionStart:startup","hook_event":"SessionStart","uuid":"def"}
+{"type":"system","subtype":"hook_completed","hook_id":"abc","hook_name":"SessionStart:startup","hook_event":"SessionStart","uuid":"def"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"here is the tailored content"}]}}
+{"type":"result","result":"{\"headline\":\"Senior Rust Dev\",\"summary\":\"Expert Rust developer.\",\"skills\":\"Rust, Go\"}","subtype":"success"}"#;
+        let result = parse_json_from_output(input).unwrap();
+        assert_eq!(result.headline, "Senior Rust Dev");
+        assert_eq!(result.skills, "Rust, Go");
     }
 
     #[test]

--- a/src/pipeline/steps.rs
+++ b/src/pipeline/steps.rs
@@ -24,7 +24,15 @@ pub async fn run_pipeline(db: &Database, config: &PipelineConfig) -> Result<Pipe
         errors:          Vec::new(),
     };
 
-    step_discover(db, config, &mut summary).await?;
+    // Discover is non-fatal: if opencli times out, continue with existing DB data
+    if let Err(e) = step_discover(db, config, &mut summary).await {
+        eprintln!("  ⚠ discover failed: {e} — continuing with existing data");
+        summary.errors.push(PipelineError {
+            id:      String::new(),
+            step:    "discover".into(),
+            message: e.to_string(),
+        });
+    }
     step_score(db, &mut summary).await?;
     let qualified = step_filter(db, config, &mut summary).await?;
     step_tailor(db, config, &qualified, &mut summary).await;


### PR DESCRIPTION
Closes #52

## Summary
- Extract stream-json and fenced-json parsing into shared `agent::output` module
- Add stream-json NDJSON extraction to `tailor.rs` (was missing — claude backend always fell back to keyword)
- Fix `extract_result_from_stream_json` returning `Some("")` instead of `None` when no result line found
- Make discover step non-fatal so pipeline continues with existing DB data on opencli timeout
- Add `git diff` validation in export to detect when agent produces no file changes

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 91 tests pass (including new stream-json tests for tailor)
- [ ] Run `tenki pipeline run` in standalone terminal and verify agent scoring/tailoring works with claude backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)